### PR TITLE
Add setting to toggle buffer chests contributing to unfulfilled request count

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -6,6 +6,12 @@ if not global.logistic_signals then
     global.logistic_signals = {};
 end
 
+local buffer_chests_enabled;
+
+local function load_settings()
+    buffer_chests_enabled = settings.global["sil-enable-buffer-chests"].value;
+end
+
 local function onEntityCreated(event)
     if (event.created_entity.valid and (event.created_entity.name == "sil-unfulfilled-requests-combinator" or event.created_entity.name == "sil-player-requests-combinator")) then
         event.created_entity.operable = false;
@@ -40,7 +46,7 @@ local function processRequests(req, requests)
     if (not (log_point and log_point.valid)) then
         return
     end
-    if (not (log_point.mode == defines.logistic_mode.buffer or log_point.mode == defines.logistic_mode.requester)) then
+    if (not ((log_point.mode == defines.logistic_mode.buffer and buffer_chests_enabled) or log_point.mode == defines.logistic_mode.requester)) then
         return
     end
     for i = 1, req.request_slot_count do
@@ -93,6 +99,10 @@ local function processRequests(req, requests)
 end
 
 local function processCombinator(obj)
+    if(not buffer_chests_enabled) then
+        load_settings();
+    end
+
     if (not (obj and obj.valid)) then
         return;
     end
@@ -145,3 +155,6 @@ script.on_event(defines.events.on_tick, function(event)
     end
 end
 );
+
+script.on_load(load_settings);
+script.on_event(defines.events.on_runtime_mod_setting_changed, load_settings);

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -11,3 +11,9 @@ sil-player-requests-combinator=Player Requests Detector
 [entity-description]
 sil-unfulfilled-requests-combinator=Provides signals for all items that are requested within the logistic network within which it is placed, but are not currently present. If a requester chest requests 100 iron plates and only has 10 in its inventory, a signal of 90 iron plates will be emitted.\nTakes into account items currently being delivered or scheduled to be taken (e.g. on buffer chests) by robots in flight.
 sil-player-requests-combinator=Provides signals for all items requested by players within the logistic network within which it is placed.\nTakes into account items currently being delivered or scheduled to be taken by robots in flight.
+
+[mod-setting-name]
+sil-enable-buffer-chests=Enable Buffer Chests 
+
+[mod-setting-description]
+sil-enable-buffer-chests=If enabled, buffer chests will contribute to the signal count of the Unfulfilled Requests Detector.

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,8 @@
+data:extend({
+    {
+        type = "bool-setting",
+        name = "sil-enable-buffer-chests",
+        setting_type = "runtime-global",
+        default_value = true
+    }
+})


### PR DESCRIPTION
Often I use Buffer Chests with high request counts to bring items from storage closer to places that use them.
The requests from these are making the Unfulfilled Request Combinator pretty useless as I don't expect the requests from these buffer chests to be completely fulfilled.

This PR adds a setting that allows a user to disable Buffer Chests from contributing to the unfulfilled count.
The setting defaults to true so there should be no change for existing users.